### PR TITLE
Update to use Azure WebJobs Extensions for OpenAI

### DIFF
--- a/inprocess-net6-openai/WhoIs.cs
+++ b/inprocess-net6-openai/WhoIs.cs
@@ -3,12 +3,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenAI;
+using Microsoft.Azure.WebJobs.Extensions.OpenAI.Models;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
-using OpenAI.ObjectModels.ResponseModels;
-using WebJobs.Extensions.OpenAI;
 
 namespace inprocess_net6_openai;
 
@@ -28,9 +28,9 @@ public class WhoIs
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "text/plain", bodyType: typeof(string), Description = "The OK response")]
     public static IActionResult Run(
         [HttpTrigger(AuthorizationLevel.Function, Route = "whois/{name}")] HttpRequest req,
-        [TextCompletion("Who is {name}?")] CompletionCreateResponse response)
+        [TextCompletion("Who is {name}?", Model = "gpt-35-turbo")] TextCompletionResponse response)
     {
-        return new OkObjectResult(response.Choices[0].Text);
+        return new OkObjectResult(response.Content);
     }
 }
 

--- a/inprocess-net6-openai/inprocess-net6-openai.csproj
+++ b/inprocess-net6-openai/inprocess-net6-openai.csproj
@@ -5,13 +5,16 @@
     <RootNamespace>inprocess_net6_openai</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CGillum.WebJobs.Extensions.OpenAI" Version="0.5.0-alpha" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenAI" Version="0.7.0-alpha" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.5.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
     <None Update="local.settings.json.default">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>

--- a/inprocess-net6-openai/local.settings.json.default
+++ b/inprocess-net6-openai/local.settings.json.default
@@ -2,6 +2,8 @@
     "IsEncrypted": false,
     "Values": {
         "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-        "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+        "AZURE_OPENAI_ENDPOINT": "https://{your-azure-openai-resource-name}.openai.azure.com/",
+        "AZURE_OPENAI_KEY": "{your-azure-openai-key}"
     }
 }


### PR DESCRIPTION
This commit updates the code to use the Microsoft Azure WebJobs Extensions for OpenAI instead of the CGillum.WebJobs.Extensions.OpenAI. The `WhoIs.cs` file and the `inprocess-net6-openai.csproj` file have been updated to reflect this change. The `TextCompletion` attribute in the `Run` method of the `WhoIs` class now specifies the model as "gpt-3.5-turbo". The `response` object in the `Run` method now uses the `Content` property instead of `Choices[0].Text`. The `local.settings.json.default` file has been updated to include the `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_KEY` settings for authentication. Lastly, the `local.settings.json` file is no longer copied to the publish directory for security reasons.